### PR TITLE
Fixing publication names by removing <xyz...>

### DIFF
--- a/general_scripting/clean_pub_name.py
+++ b/general_scripting/clean_pub_name.py
@@ -1,0 +1,41 @@
+"""
+Description: This script connects to a MongoDB database and cleans up publication names by removing <xyz> tags (modified clean_pdf_links for it to work with names)
+Date: 2023-10-31
+Author: Zéas Lupien (bhklab.zeaslupien@gmail.com, zaslup@gmail.com)
+"""
+
+import pymongo
+import os
+from dotenv import load_dotenv
+import re
+
+# Load environment variables
+load_dotenv(override=True)
+
+# Connect to MongoDB
+client = pymongo.MongoClient(os.getenv("SP_DATABASE_STRING"))
+db = client[os.getenv("DATABASE")]
+pub_collection = db[os.getenv("PUBLICATION_COLLECTION")]
+
+# Find all publications with <.*?> tags in the name field 
+#including <scp>, </scp>, <sup>, </sup>, <sub>, </sub>
+query = {
+    "name": {"$regex": "<.*?>"}
+}
+pubs = pub_collection.find(query)
+
+changed_count = 0
+
+for pub in pubs:
+    original_name = pub.get("name", "")
+    if original_name:
+        # Remove all tags like <.*?> (xyz...), <scp>, </scp>, <sup>, </sup>, <sub>, </sub>
+        cleaned_name = re.sub(r"<.*?>", "", original_name)
+        if cleaned_name != original_name:
+            pub_collection.update_one(
+                {"_id": pub["_id"]},
+                {"$set": {"name": cleaned_name}}
+            )
+            changed_count += 1
+
+print(f"\nTotal names changed: {changed_count}")

--- a/general_scripting/clean_pub_name.py
+++ b/general_scripting/clean_pub_name.py
@@ -1,6 +1,6 @@
 """
 Description: This script connects to a MongoDB database and cleans up publication names by removing <xyz> tags (modified clean_pdf_links for it to work with names)
-Date: 2023-10-31
+Date: 2025-08-01
 Author: Zéas Lupien (bhklab.zeaslupien@gmail.com, zaslup@gmail.com)
 """
 
@@ -17,8 +17,7 @@ client = pymongo.MongoClient(os.getenv("SP_DATABASE_STRING"))
 db = client[os.getenv("DATABASE")]
 pub_collection = db[os.getenv("PUBLICATION_COLLECTION")]
 
-# Find all publications with <.*?> tags in the name field 
-#including <scp>, </scp>, <sup>, </sup>, <sub>, </sub>
+# Find all publications with <.*?> tags in the name field including <scp>, </scp>, <sup>, </sup>, <sub>, </sub>
 query = {
     "name": {"$regex": "<.*?>"}
 }
@@ -26,6 +25,7 @@ pubs = pub_collection.find(query)
 
 changed_count = 0
 
+# Iterate through each publication and clean the name
 for pub in pubs:
     original_name = pub.get("name", "")
     if original_name:
@@ -37,5 +37,6 @@ for pub in pubs:
                 {"$set": {"name": cleaned_name}}
             )
             changed_count += 1
-
+            
+# print the total number of names changed
 print(f"\nTotal names changed: {changed_count}")


### PR DESCRIPTION
clean_pub_name file for removing <scp>, </scp>, <sup>, </sup>, <sub>, </sub> instances and any other possible instances with <xyz...> .